### PR TITLE
Pass the WKT as the CRS to the cloned memory layer

### DIFF
--- a/chippy_checker_utils.py
+++ b/chippy_checker_utils.py
@@ -162,7 +162,7 @@ def clone_vlayer(vlayer):
     """Clone vector layer in memory"""
     layer_type = {"0": "Point", "1": "LineString", "2": "Polygon"}
     if str(vlayer.geometryType()) in layer_type.keys():
-        str_source = layer_type[str(vlayer.geometryType())] + "?crs=epsg:" + str(vlayer.source())
+        str_source = layer_type[str(vlayer.geometryType())] + "?crs=" + str(vlayer.sourceCrs().toWkt())
     else:
         str_source = "Polygon"
     mem_layer = QgsVectorLayer(str_source, vlayer.name(), "memory")


### PR DESCRIPTION
We noticed while using the chippy editor with GeoJSON labels in 3857 format that the saved GeoJSON files in the output directory were not being correctly saved as 3857.

Upon debugging, we found the CRS was not being passed correctly.  The memory layer accepts any 

crs=definition Defines the coordinate reference system to use for the layer. definition is any string accepted by [QgsCoordinateReferenceSystem.createFromString()](https://qgis.org/pyqgis/master/core/QgsCoordinateReferenceSystem.html#qgis.core.QgsCoordinateReferenceSystem.createFromString)

We used WKT as it's the current / most complete way to specify a projection.  See https://inbo.github.io/tutorials/tutorials/spatial_crs_coding/

See
https://qgis.org/pyqgis/master/core/QgsVectorLayer.html#module-QgsVectorLayer

sourceCrs in 
https://qgis.org/pyqgis/master/core/QgsVectorDataProvider.html#module-QgsVectorDataProvider

https://qgis.org/pyqgis/master/core/QgsCoordinateReferenceSystem.html#module-QgsCoordinateReferenceSystem